### PR TITLE
Make MCU-specific `attiny-hal` globals optional

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build documentation (atmega-hal)
         run: cd mcu/atmega-hal/ && cargo doc --features atmega328p
       - name: Build documentation (attiny-hal)
-        run: cd mcu/attiny-hal/ && cargo doc --features attiny85
+        run: cd mcu/attiny-hal/ && cargo doc --features docsrs
       - name: Deploy to GH-Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/mcu/attiny-hal/Cargo.toml
+++ b/mcu/attiny-hal/Cargo.toml
@@ -24,12 +24,15 @@ critical-section-impl = ["avr-device/critical-section-impl"]
 # Allow certain downstream crates to overwrite the device selection error by themselves.
 disable-device-selection-error = []
 
-# We must select a microcontroller to build on docs.rs
-docsrs = ["attiny85"]
+default = []
+all = ["attiny84", "attiny85", "attiny88", "attiny167", "attiny2313", "no-globals"]
+docsrs = ["all"]
 
 _peripheral-adc = []
 _peripheral-spi = []
 _peripheral-simple-pwm = []
+no-globals = []
+
 
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -44,5 +44,7 @@ pub mod attiny85;
 #[cfg(feature = "attiny88")]
 pub mod attiny88;
 
+#[cfg(not(feature = "no-globals"))]
 mod globals;
+#[cfg(not(feature = "no-globals"))]
 pub use globals::*;


### PR DESCRIPTION
Use the `no-globals` flag to turn off MCU-specific globals in `attiny-hal`, which in turns allows the crate (and its docs) to be compiled with support for multiple MCUs. 