### PR TITLE
Make MCU-specific `atmega-hal` globals optional

### DIFF
--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -81,12 +81,29 @@ critical-section-impl = ["avr-device/critical-section-impl"]
 # Allow certain downstream crates to overwrite the device selection error by themselves.
 disable-device-selection-error = []
 
-# We must select a microcontroller to build on docs.rs
-docsrs = ["atmega328p"]
+default = []
+all = [
+    "atmega48p",
+    "atmega164pa",
+    "atmega168",
+    "atmega328p",
+    "atmega328pb",
+    "atmega32a",
+    "atmega32u4",
+    "atmega2560",
+    "atmega128a",
+    "atmega1280",
+    "atmega1284p",
+    "atmega8",
+    "atmega88p",
+    "no-globals",
+]
+docsrs = ["all"]
 
 _peripheral-simple-pwm = []
 _peripheral-spi = []
 _peripheral-usart = []
+no-globals = []
 
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -80,8 +80,10 @@ pub mod atmega8;
 #[cfg(feature = "atmega88p")]
 pub mod atmega88p;
 
+#[cfg(not(feature = "no-globals"))]
 mod globals;
 
 pub(crate) mod r#impl;
 
+#[cfg(not(feature = "no-globals"))]
 pub use globals::*;


### PR DESCRIPTION
Use the `no-globals` flag to turn off MCU-specific globals in `atmega-hal`, which in turns allows the crate (and its docs) to be compiled with support for multiple MCUs. 